### PR TITLE
Lighten image by using alpine

### DIFF
--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,7 +1,9 @@
-FROM ubuntu:18.04
+FROM alpine:3.14
 
-RUN apt-get update &&\
-    apt-get install -y \
+RUN apk update &&\
+    apk add --no-cache \
+      bash \
+      perl \
       make \
       gfortran \
       python3

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -5,6 +5,7 @@ RUN apk update &&\
       bash \
       perl \
       make \
+      musl-dev \
       gfortran \
       python3
       

--- a/context/Source/DHELAS/Makefile
+++ b/context/Source/DHELAS/Makefile
@@ -14,7 +14,7 @@
 # the 2003 version of MadEvent
 # ----------------------------------------------------------------------------
 
-FC = f95 -std=legacy
+FC = gfortran -std=legacy
 
 FFLAGS        = -O -I.
 

--- a/context/Source/DHELAS/Makefile.template
+++ b/context/Source/DHELAS/Makefile.template
@@ -14,7 +14,7 @@
 # the 2003 version of MadEvent
 # ----------------------------------------------------------------------------
 
-FC = f95 -std=legacy
+FC = gfortran -std=legacy
 
 FFLAGS        = -O -I.
 

--- a/context/Source/DHELAS/Makefile_dynamic
+++ b/context/Source/DHELAS/Makefile_dynamic
@@ -14,7 +14,7 @@
 # the 2003 version of MadEvent
 # ----------------------------------------------------------------------------
 
-FC = f95 -std=legacy
+FC = gfortran -std=legacy
 
 FFLAGS        = -O -fPIC -I.
 

--- a/context/Source/MODEL/makefile
+++ b/context/Source/MODEL/makefile
@@ -5,7 +5,7 @@
 #
 # ----------------------------------------------------------------------------
 
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS        = -O -ffixed-line-length-132
 LIBRARY       = ../libmodel.a
 LIBDIR        = ../../lib/

--- a/context/Source/MODEL/makefile_dynamic
+++ b/context/Source/MODEL/makefile_dynamic
@@ -5,7 +5,7 @@
 #
 # ----------------------------------------------------------------------------
 
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS        = -O -fPIC -ffixed-line-length-132
 LIBRARY       = ../libmodel.so
 LIBDIR        = ../../lib/

--- a/context/Source/MadWeight_File/Blocks/makefile
+++ b/context/Source/MadWeight_File/Blocks/makefile
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS        = -O -ffixed-line-length-132
 LIBDIR        = ../../../lib/
 CLASS = class_a.o class_b.o class_c.o class_d.o class_e.o class_f.o class_g.o

--- a/context/Source/MadWeight_File/MWP_template/makefile
+++ b/context/Source/MadWeight_File/MWP_template/makefile
@@ -1,4 +1,4 @@
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS= -O -ffixed-line-length-132
 #FFLAGS = -g -ffixed-line-length-132
 LIBDIR = ../../lib/

--- a/context/Source/MadWeight_File/Phase_Space/makefile
+++ b/context/Source/MadWeight_File/Phase_Space/makefile
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 #this is a partial combinaison
 
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS        = -O -ffixed-line-length-132
 LIBDIR        = ../../../lib/
 OBJS= get_point.o initialize.o

--- a/context/Source/MadWeight_File/Tools/makefile
+++ b/context/Source/MadWeight_File/Tools/makefile
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 G77	      = g77
 FFLAGS        = -O -ffixed-line-length-132
 LIBDIR        = ../../../lib/

--- a/context/Source/MadWeight_File/Transfer_Fct/makefile
+++ b/context/Source/MadWeight_File/Transfer_Fct/makefile
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS        = -O -ffixed-line-length-132
 LIBRARY	      = ../libTF.a
 LIBDIR        = ../../../lib/

--- a/context/Source/PDF/makefile
+++ b/context/Source/PDF/makefile
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS        = -O
 LIBRARY	      = ../libpdf.a
 LIBDIR        = ../../lib/

--- a/context/Source/PDF/makefile_dynamic
+++ b/context/Source/PDF/makefile_dynamic
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS        = -O -fPIC
 LIBRARY	      = ../libpdf.so
 LIBDIR        = ../../lib/

--- a/context/Source/makefile
+++ b/context/Source/makefile
@@ -1,4 +1,4 @@
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 #FFLAGS= -O -ffixed-line-length-132
 FFLAGS= -g -ffixed-line-length-132
 LIBDIR= ../lib/

--- a/context/Source/makefile_dynamic
+++ b/context/Source/makefile_dynamic
@@ -1,4 +1,4 @@
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS= -O -fPIC -ffixed-line-length-132
 #FFLAGS= -O 
 LIBDIR= ../lib/

--- a/context/SubProcesses/P0_e-n+_e-n+x/makefile
+++ b/context/SubProcesses/P0_e-n+_e-n+x/makefile
@@ -1,4 +1,4 @@
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS= -O -ffixed-line-length-132
 #FFLAGS = -g -ffixed-line-length-132
 LIBDIR = ../../lib/

--- a/context/SubProcesses/makefile
+++ b/context/SubProcesses/makefile
@@ -1,4 +1,4 @@
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS= -O -ffixed-line-length-132
 #FFLAGS = -g -ffixed-line-length-132
 LIBDIR = ../../lib/

--- a/context/SubProcesses/makefile_dip
+++ b/context/SubProcesses/makefile_dip
@@ -1,4 +1,4 @@
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS= -O -ffixed-line-length-132
 LIBDIR = ../../lib/
 PROG   = check

--- a/context/SubProcesses/makefile_dynamic
+++ b/context/SubProcesses/makefile_dynamic
@@ -1,4 +1,4 @@
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS= -O -fPIC -ffixed-line-length-132
 #FFLAGS = -g -ffixed-line-length-132
 LIBDIR = ../../lib/

--- a/context/SubProcesses/makefile_mo
+++ b/context/SubProcesses/makefile_mo
@@ -1,4 +1,4 @@
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS= -O -ffixed-line-length-132
 #FFLAGS = -g -ffixed-line-length-132
 LIBDIR = ../../lib/

--- a/context/SubProcesses/makefile_sa
+++ b/context/SubProcesses/makefile_sa
@@ -1,4 +1,4 @@
-F77 = f95 -std=legacy
+F77 = gfortran -std=legacy
 FFLAGS= -O -ffixed-line-length-132
 LIBDIR = ../../lib/
 PROG   = check

--- a/context/db-lib-gen.py
+++ b/context/db-lib-gen.py
@@ -19,7 +19,8 @@ lepton_options = {
     }
 
 def in_singularity() :
-    return os.path.isfile('/singularity')
+    return False
+    #return os.path.isfile('/singularity')
 
 class SafeDict(dict) :
     """ Idea for this type of look-up dictionary is provided by


### PR DESCRIPTION
This will lighten the image by a few dozen megabytes and allow us to very selectively choose the necessary packages. We are forced to use `gfortran` instead of `f95`, but my quick research shows that it should not make a difference (like switching between `clang` and `gcc` when compiling C++ code).