### PR TITLE
add in lutetium and yttrium

### DIFF
--- a/context/db-lib-gen.py
+++ b/context/db-lib-gen.py
@@ -14,6 +14,8 @@ target_options = { # Mass [GeV], A [amu], Z
     'copper'   : { 'mass' : 59.39, 'A' : 63.55, 'Z' : 29.0 }, 
     'lead'     : { 'mass' : 194.3, 'A' : 207.2, 'Z' : 82.0 }, 
     'oxygen'   : { 'mass' : 15.02, 'A' : 15.99, 'Z' :  8.0 },
+    'lutetium' : { 'mass' : 164.3, 'A' : 175.0, 'Z' : 71.0 },
+    'yttrium'  : { 'mass' : 83.57, 'A' : 89.00, 'Z' : 39.0 },
     }
 
 lepton_options = { # Mass [GeV], PDG


### PR DESCRIPTION
Got A and Z isotope-abundance-averages (rounded to 4 sig figs) from NIST:

https://www.nist.gov/pml/atomic-weights-and-isotopic-compositions-relative-atomic-masses

Used numbat.dev to convert A and Z into mass in GeV

https://numbat.dev/?q=fn+mass_gev%28atomic_mass%3A+Scalar%2C+atomic_number%3A+Scalar%29+-%3E+Energy+%3D+%28atomic_number*proton_mass+%2B+%28atomic_mass-atomic_number%29*neutron_mass%29*c%5E2+-%3E+GeV%E2%8F%8Emass_gev%28175%2C+71%29%E2%8F%8Emass_gev%2889%2C39%29%E2%8F%8E

@tvami do you need any others added while I'm at it?