### PR TITLE
Docker metadata for branches, PRs, tags and sha only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=edge,branch=${{ github.event.repository.default_branch }}
             type=sha,format=short
       -
         name: Set up QEMU


### PR DESCRIPTION
```
type=ref,event=branch -> branch_name
type=ref,event=pr -> pr-NNN
type=semver,pattern=v{{version}} -> vX.Y.Z and latest
type=sha,format=short -> sha-XXXXXXXX
```
the `type=semver` tag adds the `latest` tag by default and we'll only support `vX.Y.Z` from now on