### PR TITLE
Support Al and Ti targets

### DIFF
--- a/context/bin/dark-brem-lib-gen
+++ b/context/bin/dark-brem-lib-gen
@@ -18,6 +18,8 @@ target_options = { # Mass [GeV], A [amu], Z
     'oxygen'   : { 'mass' : 15.02, 'A' : 15.99, 'Z' :  8.0 },
     'lutetium' : { 'mass' : 164.3, 'A' : 175.0, 'Z' : 71.0 },
     'yttrium'  : { 'mass' : 83.57, 'A' : 89.00, 'Z' : 39.0 },
+    'aluminium' : { 'mass' : 25.35, 'A' : 27.0, 'Z' : 13.0 },
+    'titanium'  : { 'mass' : 44.97, 'A' : 47.9, 'Z' : 22.0 },
     }
 
 lepton_options = { # Mass [GeV], PDG


### PR DESCRIPTION
Resolves
https://github.com/LDMX-Software/dark-brem-lib-gen/issues/33

Using
https://numbat.dev/?q=fn+mass_gev%28atomic_mass%3A+Scalar%2C+atomic_number%3A+Scalar%29+-%3E+Energy+%3D+%28atomic_number*proton_mass+%2B+%28atomic_mass-atomic_number%29*neutron_mass%29*c%5E2+-%3E+GeV%E2%8F%8Emass_gev%28175%2C+71%29%E2%8F%8Emass_gev%2889%2C39%29%E2%8F%8Emass_gev%2847.9%2C+22%29%E2%8F%8Emass_gev%2827%2C+13%29%E2%8F%8E

and

https://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl?ele=Al
https://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl?ele=Ti